### PR TITLE
Set group to the real first line support group

### DIFF
--- a/lib/huntaway.rb
+++ b/lib/huntaway.rb
@@ -6,7 +6,7 @@ Dotenv.load
 Opsgenie.configure(api_key: ENV["OPSGENIE_API_KEY"])
 
 class Huntaway
-  GROUP_ID = 360008997631
+  GROUP_ID = 21306177
   OPSGENIE_SCHEDULE_ID = "e71d500f-896a-4b28-8b08-3bfe56e1ed76"
 
   def run!

--- a/spec/fixtures/group_memberships.json
+++ b/spec/fixtures/group_memberships.json
@@ -13,7 +13,7 @@
       "url": "https://example.zendesk.com/api/v2/group_memberships/144996.json",
       "id": 144996,
       "user_id": 13062170,
-      "group_id": 360008997631,
+      "group_id": 21306177,
       "default": true,
       "created_at": null,
       "updated_at": "2013-04-01T14:48:21Z"

--- a/spec/huntaway_spec.rb
+++ b/spec/huntaway_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Huntaway do
   end
 
   let!(:delete_group) { stub_delete_group_membership(144996) }
-  let!(:group_membership_creation) { stub_group_membership_creation(user_id: 375550676351, group_id: 360008997631) }
+  let!(:group_membership_creation) { stub_group_membership_creation(user_id: 375550676351, group_id: Huntaway::GROUP_ID) }
 
   it "deletes all group memberships" do
     described_class.new.run!


### PR DESCRIPTION
This changes the group that users get assigned to from the stub test group I originally used to test the script out to the actual 1st line support group. This will ensure that only those users who are on support will get 1st line support emails when they come through.